### PR TITLE
Rewrite ReportError() and change EParse to report columns in chars.

### DIFF
--- a/lslopt/lslparse.py
+++ b/lslopt/lslparse.py
@@ -44,26 +44,20 @@ def isalphanum_(c):
 def ishex(c):
     return '0' <= c <= '9' or 'A' <= c <= 'F' or 'a' <= c <= 'f'
 
-def fieldpos(inp, sep, n):
-    """Return the starting position of field n in a string inp that has zero or
-    more fields separated by sep
-    """
-    i = -1
-    for n in xrange(n):
-        i = inp.find(sep, i + 1)
-        if i < 0:
-            return i
-    return i + 1
+def GetErrLineCol(parser):
+    errorpos = parser.errorpos
+    lno = parser.script.count('\n', 0, errorpos)
+    lstart = parser.script.rfind('\n', 0, errorpos) + 1
+    # Find column number in characters
+    cno = len(parser.script[lstart:errorpos].decode('utf8'))
+    return (lno + 1, cno + 1)
 
 class EParse(Exception):
-
     def __init__(self, parser, msg):
         self.errorpos = parser.errorpos
-        self.lno = parser.script.count('\n', 0, self.errorpos)
-        self.cno = self.errorpos - fieldpos(parser.script, '\n', self.lno)
-        # Note the column number reported is in bytes.
+        self.lno, self.cno = GetErrLineCol(parser)
 
-        msg = u"(Line %d char %d): ERROR: %s" % (self.lno + 1, self.cno + 1, msg)
+        msg = u"(Line %d char %d): ERROR: %s" % (self.lno, self.cno, msg)
         super(EParse, self).__init__(msg)
 
 class EParseUEOF(EParse):

--- a/lslopt/lslparse.py
+++ b/lslopt/lslparse.py
@@ -893,6 +893,7 @@ class parser(object):
                 raise EParseUEOF(self)
             raise EParseSyntax(self)
         name = val
+        idpos = self.errorpos
         self.NextToken()
 
         # Course of action decided here.
@@ -904,9 +905,11 @@ class parser(object):
             # Functions are looked up in the global scope only.
             sym = self.FindSymbolFull(val, 0)
             if sym is None:
+                self.errorpos = idpos
                 raise EParseUndefined(self)
 
             if sym['Kind'] != 'f':
+                self.errorpos = idpos
                 raise EParseUndefined(self)
             args = self.Parse_optional_expression_list(sym['ParamTypes'])
             self.expect(')')
@@ -915,6 +918,7 @@ class parser(object):
 
         sym = self.FindSymbolFull(val)
         if sym is None or sym['Kind'] != 'v':
+            self.errorpos = idpos
             raise EParseUndefined(self)
 
         typ = sym['Type']

--- a/testparser.py
+++ b/testparser.py
@@ -21,7 +21,7 @@
 from lslopt.lslparse import parser,EParseSyntax,EParseUEOF,EParseAlreadyDefined,\
     EParseUndefined,EParseTypeMismatch,EParseReturnShouldBeEmpty,EParseReturnIsEmpty,\
     EParseInvalidField,EParseFunctionMismatch,EParseDeclarationScope,\
-    EParseDuplicateLabel,EParseCantChangeState,EParseCodePathWithoutRet,fieldpos
+    EParseDuplicateLabel,EParseCantChangeState,EParseCodePathWithoutRet
 from lslopt.lsloutput import outscript
 from lslopt.lsloptimizer import optimizer
 from lslopt import lslfuncs
@@ -217,7 +217,6 @@ class Test02_Parser(UnitTestCase):
             ))
         print self.parser.scopeindex
 
-        self.assertEqual(fieldpos("a,b", ",", 3), -1)
         self.assertEqual(self.outscript.Value2LSL(lslfuncs.Key(u'')), '((key)"")')
         self.assertRaises(AssertionError, self.outscript.Value2LSL, '')
 
@@ -528,7 +527,7 @@ class Test03_Optimizer(UnitTestCase):
             self.assertFalse(True)
         except EParseSyntax as e:
             # should err before first closing brace
-            self.assertEqual(e.cno, 27)
+            self.assertEqual(e.cno, 28)
         except:
             # should raise no other exception
             self.assertFalse(True)


### PR DESCRIPTION
ReportError() needed to account for terminal encodings that don't support the characters being printed. It was also reporting an inaccurate column number and its corresponding marker position, because the count was in bytes, not in characters, so that has been fixed.
